### PR TITLE
Add routing policy pattern: Inbound route filtering with prefix lists

### DIFF
--- a/patterns/4-routing_policies/9-inbound_route_filtering/README.md
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/README.md
@@ -1,0 +1,99 @@
+# 9. Inbound Route Filtering with Prefix Lists
+
+> **⚠️ Hybrid Environment Required**: This pattern requires you to establish hybrid connectivity (Direct Connect Gateway or Site-to-Site VPN) with BGP sessions advertising routes from on-premises. The IaC code creates the Cloud WAN infrastructure and prefix list, but you must configure your on-premises router to advertise routes for testing.
+
+This pattern demonstrates how to **drop dangerous routes advertised from on-premises** before they enter your Cloud WAN segments. This is a day-1 security requirement for any hybrid deployment — without inbound filtering, on-premises can accidentally (or maliciously) advertise routes that overlap with your VPC CIDRs or attract all traffic via a default route.
+
+## Problem
+
+On-premises routers advertise routes via BGP over Direct Connect or VPN. Without filtering, these routes propagate into your Cloud WAN segments. Dangerous scenarios include:
+
+| Advertised Route | Risk |
+|---|---|
+| `0.0.0.0/0` | Default route attracts ALL traffic to on-prem, blackholing cloud workloads |
+| `10.0.0.0/16` | Overlaps with production VPC CIDR — causes routing conflicts |
+| `10.0.0.0/8` | Supernet covers all VPCs — on-prem becomes preferred path for east-west traffic |
+
+## Solution
+
+Use a **routing policy** with `prefix-in-prefix-list` match condition to drop specific prefixes inbound from hybrid attachments before they enter the segment route table.
+
+### Key Components
+
+| Component | Configuration |
+|-----------|---------------|
+| **Regions** | us-east-1, eu-west-1 |
+| **Segments** | `production`, `hybrid` |
+| **Routing Policy** | `inboundDropDangerousRoutes` (direction: inbound) |
+| **Match Condition** | `prefix-in-prefix-list` → `dangerousPrefixes` |
+| **Action** | `drop` |
+| **Policy Association** | Via routing-policy-label `hybridRouteFiltering` on DX attachment |
+
+### How It Works
+
+1. On-premises advertises routes via BGP: `192.168.0.0/24`, `10.0.0.0/16`, `0.0.0.0/0`
+2. Cloud WAN receives routes on the hybrid segment attachment
+3. **Before** routes enter the segment route table, the inbound routing policy evaluates them
+4. Routes matching the prefix list (`0.0.0.0/0`, `10.0.0.0/16`, `10.0.0.0/8`) are **dropped**
+5. Only safe routes (`192.168.0.0/24`) propagate into the hybrid segment
+6. Safe routes are then shared with the production segment via segment-actions
+
+### Traffic Flow
+
+| Advertised from On-Prem | In Prefix List? | Result |
+|---|---|---|
+| `192.168.0.0/24` | ❌ No | ✅ Accepted into hybrid segment |
+| `192.168.10.0/24` | ❌ No | ✅ Accepted into hybrid segment |
+| `0.0.0.0/0` | ✅ Yes | ❌ **Dropped** (dangerous default route) |
+| `10.0.0.0/16` | ✅ Yes | ❌ **Dropped** (overlaps with VPC CIDR) |
+| `10.0.0.0/8` | ✅ Yes | ❌ **Dropped** (supernet covers all VPCs) |
+
+## Implementation
+
+| IaC Tool | Location |
+|----------|----------|
+| **CloudFormation** | [`./cloudformation/`](./cloudformation/) |
+| **Terraform** | [`./terraform/`](./terraform/) |
+
+### Post-Deployment Step (Required)
+
+After deploying the infrastructure, you must associate the prefix list with the Core Network. This step is required because there is no native Terraform/CloudFormation resource for this operation yet:
+
+```bash
+aws networkmanager create-core-network-prefix-list-association \
+  --core-network-id <core-network-id> \
+  --prefix-list-arn <prefix-list-arn> \
+  --prefix-list-alias "dangerousPrefixes" \
+  --region us-east-1
+```
+
+For CloudFormation deployments, use `make associate-prefix-list` which handles this automatically.
+
+## Verification
+
+After deployment and prefix list association:
+
+1. Advertise `192.168.0.0/24` from on-premises → should appear in hybrid segment routes
+2. Advertise `0.0.0.0/0` from on-premises → should NOT appear in hybrid segment routes
+3. Advertise `10.0.0.0/16` from on-premises → should NOT appear (overlaps with VPC)
+
+Check routes:
+```bash
+aws networkmanager get-network-routes \
+  --global-network-id <global-network-id> \
+  --route-table-identifier '{"CoreNetworkSegmentEdge": {"CoreNetworkId": "<core-network-id>", "SegmentName": "hybrid", "EdgeLocation": "us-east-1"}}' \
+  --region us-east-1
+```
+
+## Updating the Prefix List
+
+To add or remove prefixes from the drop list, update the managed prefix list:
+
+```bash
+aws ec2 modify-managed-prefix-list \
+  --prefix-list-id <prefix-list-id> \
+  --add-entries '[{"Cidr": "172.16.0.0/12", "Description": "Block RFC1918 supernet"}]' \
+  --current-version <current-version>
+```
+
+Changes take effect immediately — no policy redeployment needed.

--- a/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/Makefile
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/Makefile
@@ -1,0 +1,21 @@
+.PHONY: deploy associate-prefix-list undeploy
+
+deploy:
+	aws cloudformation deploy \
+		--stack-name core-network-inbound-route-filtering \
+		--template-file core_network.yaml \
+		--no-fail-on-empty-changeset \
+		--region us-east-1
+
+associate-prefix-list: CORENETWORK_ID = $(shell aws cloudformation describe-stacks --stack-name "core-network-inbound-route-filtering" --query 'Stacks[0].Outputs[?OutputKey == `CoreNetworkId`].OutputValue' --output text --region us-east-1)
+associate-prefix-list: PREFIX_LIST_ARN = $(shell aws cloudformation describe-stacks --stack-name "core-network-inbound-route-filtering" --query 'Stacks[0].Outputs[?OutputKey == `PrefixListArn`].OutputValue' --output text --region us-east-1)
+associate-prefix-list:
+	aws networkmanager create-core-network-prefix-list-association \
+		--core-network-id "$(CORENETWORK_ID)" \
+		--prefix-list-arn "$(PREFIX_LIST_ARN)" \
+		--prefix-list-alias "dangerousPrefixes" \
+		--region us-east-1
+
+undeploy:
+	aws cloudformation delete-stack --stack-name core-network-inbound-route-filtering --region us-east-1
+	aws cloudformation wait stack-delete-complete --stack-name core-network-inbound-route-filtering --region us-east-1

--- a/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/README.md
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/README.md
@@ -1,0 +1,26 @@
+# AWS Cloud WAN Inbound Route Filtering (AWS CloudFormation)
+
+## Prerequisites
+
+- **AWS Account**: With appropriate IAM permissions
+- **AWS CLI**: Installed and configured
+- **Hybrid Connectivity**: Direct Connect Gateway with BGP sessions established
+- **Make**: Installed
+
+## Deployment
+
+```bash
+cd patterns/4-routing_policies/9-inbound_route_filtering/cloudformation
+
+# Deploy Core Network + DX Gateway + Prefix List
+make deploy
+
+# After deployment, associate the prefix list with the Core Network:
+make associate-prefix-list
+```
+
+## Cleanup
+
+```bash
+make undeploy
+```

--- a/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/core_network.yaml
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/cloudformation/core_network.yaml
@@ -1,0 +1,139 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS Cloud WAN Inbound Route Filtering with Prefix Lists
+
+Parameters:
+  DxGatewayAsn:
+    Type: Number
+    Default: 64512
+    Description: ASN for the Direct Connect Gateway.
+
+Resources:
+  # ---------- CLOUD WAN ----------
+  GlobalNetwork:
+    Type: AWS::NetworkManager::GlobalNetwork
+    Properties:
+      Description: Global Network - Inbound Route Filtering
+      Tags:
+        - Key: Name
+          Value: global-network-inbound-route-filtering
+
+  CoreNetwork:
+    Type: AWS::NetworkManager::CoreNetwork
+    Properties:
+      Description: Core Network - Inbound Route Filtering
+      GlobalNetworkId: !Ref GlobalNetwork
+      Tags:
+        - Key: Name
+          Value: core-network-inbound-route-filtering
+      PolicyDocument:
+        version: "2025.11"
+        core-network-configuration:
+          vpn-ecmp-support: true
+          asn-ranges:
+            - 65000-65003
+          edge-locations:
+            - location: us-east-1
+            - location: eu-west-1
+        segments:
+          - name: production
+            require-attachment-acceptance: false
+          - name: hybrid
+            require-attachment-acceptance: false
+        network-function-groups: []
+        segment-actions:
+          - action: share
+            mode: attachment-route
+            segment: hybrid
+            share-with:
+              - production
+          - action: share
+            mode: attachment-route
+            segment: production
+            share-with:
+              - hybrid
+        attachment-policies:
+          - rule-number: 100
+            condition-logic: or
+            conditions:
+              - type: tag-value
+                operator: equals
+                key: segment
+                value: production
+            action:
+              association-method: constant
+              segment: production
+          - rule-number: 200
+            condition-logic: or
+            conditions:
+              - type: tag-value
+                operator: equals
+                key: segment
+                value: hybrid
+            action:
+              association-method: constant
+              segment: hybrid
+        attachment-routing-policy-rules:
+          - rule-number: 100
+            description: Apply inbound drop policy to hybrid attachments
+            conditions:
+              - type: routing-policy-label
+                value: hybridRouteFiltering
+            action:
+              associate-routing-policies:
+                - inboundDropDangerousRoutes
+        routing-policies:
+          - routing-policy-name: inboundDropDangerousRoutes
+            routing-policy-description: Drop dangerous routes from on-premises
+            routing-policy-direction: inbound
+            routing-policy-number: 100
+            routing-policy-rules:
+              - rule-number: 100
+                rule-definition:
+                  match-conditions:
+                    - type: prefix-in-prefix-list
+                      value: dangerousPrefixes
+                  condition-logic: or
+                  action:
+                    type: drop
+
+  # ---------- DIRECT CONNECT GATEWAY ----------
+  DxGateway:
+    Type: AWS::DirectConnect::DirectConnectGateway
+    Properties:
+      DirectConnectGatewayName: dxgw-inbound-route-filtering
+      AmazonSideAsn: !Ref DxGatewayAsn
+
+  # ---------- PREFIX LIST ----------
+  DangerousPrefixList:
+    Type: AWS::EC2::PrefixList
+    Properties:
+      PrefixListName: dangerous-prefixes
+      AddressFamily: IPv4
+      MaxEntries: 10
+      Entries:
+        - Cidr: "0.0.0.0/0"
+          Description: Block default route from on-premises
+        - Cidr: "10.0.0.0/16"
+          Description: Block overlap with prod-us-east-1 VPC CIDR
+        - Cidr: "10.0.0.0/8"
+          Description: Block broad supernet from on-premises
+      Tags:
+        - Key: Name
+          Value: dangerous-prefixes
+
+Outputs:
+  CoreNetworkId:
+    Description: Core Network ID.
+    Value: !GetAtt CoreNetwork.CoreNetworkId
+  CoreNetworkArn:
+    Description: Core Network ARN.
+    Value: !GetAtt CoreNetwork.CoreNetworkArn
+  DxGatewayId:
+    Description: Direct Connect Gateway ID.
+    Value: !Ref DxGateway
+  PrefixListId:
+    Description: Managed Prefix List ID for dangerous routes.
+    Value: !Ref DangerousPrefixList
+  PrefixListArn:
+    Description: Managed Prefix List ARN.
+    Value: !GetAtt DangerousPrefixList.Arn

--- a/patterns/4-routing_policies/9-inbound_route_filtering/cloudwan_policy.json
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/cloudwan_policy.json
@@ -1,0 +1,102 @@
+{
+  "version": "2025.11",
+  "core-network-configuration": {
+    "vpn-ecmp-support": true,
+    "asn-ranges": ["65000-65003"],
+    "edge-locations": [
+      { "location": "us-east-1" },
+      { "location": "eu-west-1" }
+    ]
+  },
+  "segments": [
+    {
+      "name": "production",
+      "require-attachment-acceptance": false
+    },
+    {
+      "name": "hybrid",
+      "require-attachment-acceptance": false
+    }
+  ],
+  "network-function-groups": [],
+  "segment-actions": [
+    {
+      "action": "share",
+      "mode": "attachment-route",
+      "segment": "hybrid",
+      "share-with": ["production"]
+    },
+    {
+      "action": "share",
+      "mode": "attachment-route",
+      "segment": "production",
+      "share-with": ["hybrid"]
+    }
+  ],
+  "attachment-policies": [
+    {
+      "rule-number": 100,
+      "condition-logic": "or",
+      "conditions": [
+        {
+          "type": "tag-value",
+          "operator": "equals",
+          "key": "segment",
+          "value": "production"
+        }
+      ],
+      "action": {
+        "association-method": "constant",
+        "segment": "production"
+      }
+    },
+    {
+      "rule-number": 200,
+      "condition-logic": "or",
+      "conditions": [
+        {
+          "type": "tag-value",
+          "operator": "equals",
+          "key": "segment",
+          "value": "hybrid"
+        }
+      ],
+      "action": {
+        "association-method": "constant",
+        "segment": "hybrid"
+      }
+    }
+  ],
+  "attachment-routing-policy-rules": [
+    {
+      "rule-number": 100,
+      "description": "Apply inbound drop policy to hybrid attachments",
+      "conditions": [
+        { "type": "routing-policy-label", "value": "hybridRouteFiltering" }
+      ],
+      "action": {
+        "associate-routing-policies": ["inboundDropDangerousRoutes"]
+      }
+    }
+  ],
+  "routing-policies": [
+    {
+      "routing-policy-name": "inboundDropDangerousRoutes",
+      "routing-policy-description": "Drop dangerous routes from on-premises: default route and prefixes that overlap with VPC CIDRs",
+      "routing-policy-direction": "inbound",
+      "routing-policy-number": 100,
+      "routing-policy-rules": [
+        {
+          "rule-number": 100,
+          "rule-definition": {
+            "match-conditions": [
+              { "type": "prefix-in-prefix-list", "value": "dangerousPrefixes" }
+            ],
+            "condition-logic": "or",
+            "action": { "type": "drop" }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/patterns/4-routing_policies/9-inbound_route_filtering/terraform/main.tf
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/terraform/main.tf
@@ -1,0 +1,149 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: MIT-0 */
+
+# --- patterns/4-routing_policies/9-inbound_route_filtering/terraform/main.tf ---
+
+data "aws_caller_identity" "current" {}
+
+# ---------- AWS CLOUD WAN RESOURCES ----------
+resource "awscc_networkmanager_global_network" "global_network" {
+  description = "Global Network - ${var.identifier}"
+
+  tags = [{
+    key   = "Name"
+    value = "global-network-${var.identifier}"
+  }]
+}
+
+resource "awscc_networkmanager_core_network" "core_network" {
+  global_network_id = awscc_networkmanager_global_network.global_network.id
+  description       = "Core Network - ${var.identifier}"
+  policy_document   = file("${path.module}/cloudwan_policy.json")
+
+  tags = [{
+    key   = "Name"
+    value = "core-network-${var.identifier}"
+  }]
+}
+
+# ---------- SPOKE VPCs ----------
+module "nvirginia_spoke_vpcs" {
+  for_each  = var.nvirginia_spoke_vpcs
+  source    = "aws-ia/vpc/aws"
+  version   = "= 4.7.3"
+  providers = { aws = aws.awsnvirginia }
+
+  name       = each.key
+  cidr_block = each.value.cidr_block
+  az_count   = each.value.number_azs
+
+  core_network = {
+    id  = awscc_networkmanager_core_network.core_network.core_network_id
+    arn = awscc_networkmanager_core_network.core_network.core_network_arn
+  }
+  core_network_routes = {
+    workload = "0.0.0.0/0"
+  }
+
+  subnets = {
+    workload = { netmask = each.value.workload_subnet_netmask }
+    core_network = {
+      netmask            = each.value.cnetwork_subnet_netmask
+      require_acceptance = false
+
+      tags = {
+        segment = each.value.segment
+      }
+    }
+  }
+}
+
+module "ireland_spoke_vpcs" {
+  for_each  = var.ireland_spoke_vpcs
+  source    = "aws-ia/vpc/aws"
+  version   = "= 4.7.3"
+  providers = { aws = aws.awsireland }
+
+  name       = each.key
+  cidr_block = each.value.cidr_block
+  az_count   = each.value.number_azs
+
+  core_network = {
+    id  = awscc_networkmanager_core_network.core_network.core_network_id
+    arn = awscc_networkmanager_core_network.core_network.core_network_arn
+  }
+  core_network_routes = {
+    workload = "0.0.0.0/0"
+  }
+
+  subnets = {
+    workload = { netmask = each.value.workload_subnet_netmask }
+    core_network = {
+      netmask            = each.value.cnetwork_subnet_netmask
+      require_acceptance = false
+
+      tags = {
+        segment = each.value.segment
+      }
+    }
+  }
+}
+
+# ---------- HYBRID CONNECTIVITY (DX Gateway) ----------
+resource "aws_dx_gateway" "dxgw" {
+  provider = aws.awsnvirginia
+
+  name            = "dxgw-${var.identifier}"
+  amazon_side_asn = var.dx_gateway_asn
+}
+
+resource "aws_networkmanager_dx_gateway_attachment" "hybrid" {
+  provider = aws.awsnvirginia
+
+  core_network_id            = awscc_networkmanager_core_network.core_network.core_network_id
+  direct_connect_gateway_arn = "arn:aws:directconnect::${data.aws_caller_identity.current.account_id}:dx-gateway/${aws_dx_gateway.dxgw.id}"
+  edge_locations             = values(var.aws_regions)
+
+  tags = {
+    segment              = "hybrid"
+    routing-policy-label = "hybridRouteFiltering"
+  }
+}
+
+# ---------- PREFIX LIST (dangerous routes to drop) ----------
+resource "aws_ec2_managed_prefix_list" "dangerous_prefixes" {
+  provider = aws.awsnvirginia
+
+  name           = "dangerous-prefixes-${var.identifier}"
+  address_family = "IPv4"
+  max_entries    = 10
+
+  # Drop default route from on-prem (prevents route leak)
+  entry {
+    cidr        = "0.0.0.0/0"
+    description = "Block default route from on-premises"
+  }
+
+  # Drop prefix that overlaps with production VPC CIDR
+  entry {
+    cidr        = "10.0.0.0/16"
+    description = "Block overlap with prod-us-east-1 VPC CIDR"
+  }
+
+  # Drop RFC1918 supernet that would attract all private traffic
+  entry {
+    cidr        = "10.0.0.0/8"
+    description = "Block broad supernet from on-premises"
+  }
+
+  tags = {
+    Name = "dangerous-prefixes-${var.identifier}"
+  }
+}
+
+# NOTE: Prefix list association with Core Network requires AWS CLI:
+# aws networkmanager create-core-network-prefix-list-association \
+#   --core-network-id <core-network-id> \
+#   --prefix-list-arn <prefix-list-arn> \
+#   --prefix-list-alias "dangerousPrefixes" \
+#   --region us-east-1

--- a/patterns/4-routing_policies/9-inbound_route_filtering/terraform/outputs.tf
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/terraform/outputs.tf
@@ -1,0 +1,28 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: MIT-0 */
+
+# --- patterns/4-routing_policies/9-inbound_route_filtering/terraform/outputs.tf ---
+
+output "cloud_wan" {
+  description = "AWS Cloud WAN resources."
+  value = {
+    global_network = awscc_networkmanager_global_network.global_network.global_network_id
+    core_network   = awscc_networkmanager_core_network.core_network.core_network_id
+  }
+}
+
+output "dx_gateway" {
+  description = "Direct Connect Gateway."
+  value = {
+    id  = aws_dx_gateway.dxgw.id
+    asn = aws_dx_gateway.dxgw.amazon_side_asn
+  }
+}
+
+output "prefix_list" {
+  description = "Managed prefix list for dangerous routes."
+  value = {
+    id  = aws_ec2_managed_prefix_list.dangerous_prefixes.id
+    arn = aws_ec2_managed_prefix_list.dangerous_prefixes.arn
+  }
+}

--- a/patterns/4-routing_policies/9-inbound_route_filtering/terraform/providers.tf
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/terraform/providers.tf
@@ -1,0 +1,33 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: MIT-0 */
+
+# --- patterns/4-routing_policies/9-inbound_route_filtering/terraform/providers.tf ---
+
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.67.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_regions.nvirginia
+  alias  = "awsnvirginia"
+}
+
+provider "awscc" {
+  region = var.aws_regions.nvirginia
+  alias  = "awsccnvirginia"
+}
+
+provider "aws" {
+  region = var.aws_regions.ireland
+  alias  = "awsireland"
+}

--- a/patterns/4-routing_policies/9-inbound_route_filtering/terraform/variables.tf
+++ b/patterns/4-routing_policies/9-inbound_route_filtering/terraform/variables.tf
@@ -1,0 +1,53 @@
+/* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: MIT-0 */
+
+# --- patterns/4-routing_policies/9-inbound_route_filtering/terraform/variables.tf ---
+
+variable "identifier" {
+  type        = string
+  description = "Project Identifier."
+  default     = "inbound-route-filtering"
+}
+
+variable "aws_regions" {
+  type        = map(string)
+  description = "AWS Regions for Cloud WAN edge locations."
+  default = {
+    nvirginia = "us-east-1"
+    ireland   = "eu-west-1"
+  }
+}
+
+variable "dx_gateway_asn" {
+  type        = number
+  description = "ASN for the Direct Connect Gateway."
+  default     = 64512
+}
+
+variable "nvirginia_spoke_vpcs" {
+  type        = any
+  description = "VPCs to create in us-east-1."
+  default = {
+    "prod-us-east-1" = {
+      segment                 = "production"
+      number_azs              = 2
+      cidr_block              = "10.0.0.0/16"
+      workload_subnet_netmask = 24
+      cnetwork_subnet_netmask = 28
+    }
+  }
+}
+
+variable "ireland_spoke_vpcs" {
+  type        = any
+  description = "VPCs to create in eu-west-1."
+  default = {
+    "prod-eu-west-1" = {
+      segment                 = "production"
+      number_azs              = 2
+      cidr_block              = "10.10.0.0/16"
+      workload_subnet_netmask = 24
+      cnetwork_subnet_netmask = 28
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds **pattern 9** to the routing policies section: Inbound route filtering using managed prefix lists to drop dangerous routes from on-premises before they enter Cloud WAN segments.

## Problem This Solves

Without inbound filtering, on-premises routers can advertise routes that:
- Overlap with VPC CIDRs (routing conflicts)
- Advertise default routes (blackhole cloud traffic)
- Advertise broad supernets (attract east-west traffic to on-prem)

## What's Included

- Routing policy with `prefix-in-prefix-list` match condition and `drop` action
- Managed prefix list with dangerous prefixes (0.0.0.0/0, VPC CIDR overlaps, supernets)
- Attachment routing policy rules with `routing-policy-label` for selective application
- DX Gateway attachment with the filtering label applied
- Terraform and CloudFormation implementations
- Standalone `cloudwan_policy.json`
- Post-deployment step for prefix list association (CLI required)

## Why This Is Not Covered by Existing Patterns

Existing patterns cover:
- Filtering secondary CIDRs (pattern 1) — outbound from VPC, not inbound from hybrid
- BGP community filtering (pattern 4) — segments traffic, doesn't drop it
- Filtering peered TGWs (pattern 8) — TGW-specific, not hybrid inbound

This pattern is the only one demonstrating **inbound drop policies on hybrid attachments** using prefix lists — a day-1 security requirement for any DX/VPN deployment.

## Related Issue

Relates to #17

## Author

Renato Gentil