### PR TITLE
docs(policy): Document per-CNE routing policy association on one label

### DIFF
--- a/policy/7-routing_policies.md
+++ b/policy/7-routing_policies.md
@@ -421,7 +421,7 @@ This is commonly associated at the attachment scope — see [`9-attachment_routi
 
 A Direct Connect gateway attaches to every CNE. If every CNE advertises the same `10.0.0.0/8`, on-premises routers see equal-cost paths; traffic for a `eu-west-1` workload can enter through `us-east-1` and cross the backbone.
 
-Create one summarization policy per Region's supernet — for example, `summarizeNVirginiaIpv4Routes` for `10.10.0.0/16` and `summarizeIrelandIpv4Routes` for `10.0.0.0/16` — and scope each policy to its Region with [`edge-locations`](./9-attachment_routing_policy_rules.md#edge-locations). Each CNE then advertises only its Region's space, so on-premises traffic enters through the nearest Region.
+Create one summarization policy per Region's supernet — for example, `summarizeNVirginiaIpv4Routes` for `10.10.0.0/16` and `summarizeIrelandIpv4Routes` for `10.0.0.0/16` — and bind each to its Region with one `attachment-routing-policy-rules` entry per Region, matching the attachment's one label and scoped with `edge-locations` — see [Different routing policies per CNE on one attachment](./9-attachment_routing_policy_rules.md#different-routing-policies-per-cne-on-one-attachment). Each CNE then advertises only its Region's space, so on-premises traffic enters through the nearest Region.
 
 ### `prepend-asn-list`: AS_PATH prepending to prefer one Region's hybrid edge
 

--- a/policy/9-attachment_routing_policy_rules.md
+++ b/policy/9-attachment_routing_policy_rules.md
@@ -1,6 +1,6 @@
 ---
 title: "Cloud WAN attachment routing policy rules: binding routing policies to attachments with labels"
-description: "How attachment-routing-policy-rules associate AWS Cloud WAN routing policies with attachments through a routing-policy label, what inbound and outbound mean at attachment scope, and how to limit a rule to specific Regions. Includes the cross-account ordering problem when the attachment owner cannot set its own label."
+description: "How attachment-routing-policy-rules associate AWS Cloud WAN routing policies with attachments through a routing-policy label, what inbound and outbound mean at attachment scope, and how edge-locations scopes a rule so one Direct Connect gateway attachment carries different routing policies per CNE. Includes the cross-account ordering problem when the attachment owner cannot set its own label."
 ---
 
 # Attachment routing policy rules
@@ -36,9 +36,9 @@ Use `description` to state the routing treatment the rule assigns. It makes the 
 
 ## `conditions`
 
-`routing-policy-label` is the only condition type. Think of the label as an attachment's routing-treatment name: each attachment has one label, and the label determines which attachment-routing rule applies.
+`routing-policy-label` is the only condition type. Think of the label as an attachment's routing-treatment name: each attachment has one label, and the label determines which attachment-routing rules apply.
 
-A rule can accept one or more labels. Any listed label matches. Because an attachment has one label, attachments that need a different policy set need a different label and a separate rule.
+A rule can accept one or more labels. Any listed label matches. Because an attachment has one label, two attachments that need different treatment need different labels. One attachment can still be treated differently per Region, though: several rules may match the same label, and [`edge-locations`](#edge-locations) below decides where each applies.
 
 ```json
 {
@@ -86,7 +86,52 @@ The attachment rule selects **which attachments** receive the policies. In this 
 
 ## `edge-locations`
 
-`edge-locations` limits a matching rule's policy association to selected CNE Regions. It is useful for Direct Connect attachments, which can associate with multiple CNEs. Without the field, a matching policy applies at every CNE associated with the attachment; with it, the policy applies only at the listed Regions.
+`edge-locations` limits a matching rule's policy association to selected CNE Regions. It is useful for Direct Connect gateway attachments, which can associate with multiple CNEs. Without the field, a matching policy applies at every CNE associated with the attachment; with it, the policy applies only at the listed Regions.
+
+### Different routing policies per CNE on one attachment
+
+When several rules match the same label, each rule is honoured independently, at the Regions its own `edge-locations` names. That is what gives one attachment different routing treatment per CNE — and it matters most for the Direct Connect gateway attachment, the type that associates with multiple CNEs:
+
+```json
+[
+  {
+    "rule-number": 100,
+    "description": "N. Virginia: global filter plus AS_PATH prepend to de-prefer this Region's path to on-premises",
+    "edge-locations": ["us-east-1"],
+    "conditions": [
+      {
+        "type": "routing-policy-label",
+        "value": "dxAttachment"
+      }
+    ],
+    "action": {
+      "associate-routing-policies": ["filterDecommissionedRoutes", "depreferNVirginiaPath"]
+    }
+  },
+  {
+    "rule-number": 200,
+    "description": "Ireland: global filter only",
+    "edge-locations": ["eu-west-1"],
+    "conditions": [
+      {
+        "type": "routing-policy-label",
+        "value": "dxAttachment"
+      }
+    ],
+    "action": {
+      "associate-routing-policies": ["filterDecommissionedRoutes"]
+    }
+  }
+]
+```
+
+Both rules match the `dxAttachment` label, so both apply — each at the Regions it names. Rules do not merge: a rule associates exactly what its action lists, so a policy meant for every CNE is repeated in every action, as `filterDecommissionedRoutes` is here. `depreferNVirginiaPath` applies only at `us-east-1` — there it could, for example, prepend AS_PATH to the on-premises routes learned at that CNE, so traffic toward on-premises prefers the Ireland path with N. Virginia as failover.
+
+> **Labels distinguish attachments; `edge-locations` distinguishes Regions.** Only the Direct Connect gateway *needs* this — one attachment, one label, several CNEs. For single-Region types it is a convention choice: one stable label plus Region-scoped rules keeps regional variation in the policy document, instead of encoding Regions into labels and re-labeling live attachments when treatment changes. Two attachments in the same Region that need different treatment still need different labels.
+
+Two things complete the picture. Where a rule binds several policies at the same CNE — `us-east-1` above — their [`routing-policy-number`](./7-routing_policies.md#routing-policy-number-running-multiple-policies-on-the-same-resource) orders them, per CNE. And direction still belongs to each policy, not to the rule: both policies here happen to act inbound, on routes learned from the attachment — an outbound policy binds exactly the same way.
+
+> **A Region no rule covers gets no policies — silently.** Add a Region to the core network later and the Direct Connect gateway attachment extends there, but no rule names it, so routes at that CNE flow unfiltered and unmodified, with no error anywhere. Review the rule set whenever `edge-locations` change — in the policy document or on the attachment.
 
 ## Creation-time dependency
 


### PR DESCRIPTION
## Description

`attachment-routing-policy-rules` honours `edge-locations` independently when several rules match the same routing-policy label: each rule associates its policies only at the Regions it names. This lets a single attachment — in practice the Direct Connect gateway attachment, the one type that spans multiple CNEs — carry different routing policies per CNE, with a global policy expressed by repeating it in every regional action. Neither page documented this; page 9's wording actively implied one label maps to one rule.

Changes:

- `policy/9-attachment_routing_policy_rules.md`: reworded `conditions` so it no longer forecloses multiple rules per label; new section *Different routing policies per CNE on one attachment* under `edge-locations` with a binding-only snippet (global filter in both regional actions, Region-specific policy in one); callouts for the labels-vs-`edge-locations` rule of thumb and the silently-uncovered-Region trap; frontmatter description updated.
- `policy/7-routing_policies.md`: one sentence — the DXGW per-Region summarization use case now names the actual binding mechanism (one rule per Region, same label) and links to the new section. Policy contents stay on page 7, binding stays on page 9.

## Where is the change?

- [ ] `infra/` — a deployable infrastructure pattern
- [x] `policy/` — a policy capability page or its snippets
- [x] `SKILLS.md` — agent knowledge or generator logic

## Checklist for every change

- [x] I have read [CONVENTIONS.md](../CONVENTIONS.md) and this change conforms to it.
- [x] `pre-commit run --all-files` passes locally (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I reviewed advisory Checkov findings — no IaC touched, none apply.

## If the change is in `policy/`

- [x] Examples remain composable snippets — the new example is a rules array only;
  the routing policies it names are deliberately not defined.
- [x] The capability indexes agree — no new page, no index changes needed.
- [x] Any new constraint or caveat is also reflected in `SKILLS.md` — **see note below.**
- [x] Fenced JSON snippets parse (`python3 .github/scripts/check_policies.py` — 65 snippets OK).

## Testing

Verified on a live two-Region core network (us-east-1 / eu-west-1) with a Direct Connect gateway attachment: one routing-policy label, two rules matching it with different `edge-locations`, each associating a different routing policy — both honoured, each only at its Region. Static checks (snippet parsing, anchor resolution) pass locally. The no-merge-between-rules behaviour is asserted from this testing; the AWS documentation does not yet describe the multiple-rules-same-label case.